### PR TITLE
Update README.md

### DIFF
--- a/DeskReservation/README.md
+++ b/DeskReservation/README.md
@@ -52,7 +52,7 @@ None
 
 This template uses SharePoint as it's main data source and consists of two different lists.
 
-### Desks List
+### List Name: Desks
 
 This SharePoint list contains the information about the desks that people can book.  Set the list up as follows:
 
@@ -64,14 +64,14 @@ This SharePoint list contains the information about the desks that people can bo
 |Number|Active|No|
 |Single line of text|Floor|No|
 
-### Desks Reservations List
+### List Name: Desk Reservations
 
 This SharePoint list contains the reservation information.  Set the list up as follows:
 
 |Type|Internal Name|Required|
 |---|---|:---:|
 |Single line of text|Title|Yes|
-|Single line of text|DeskText|Yes|
+|Single line of text|Desk Text|Yes|
 |Person or Group|Reserved By|Yes|
 |Date and Time|Check Out From|No|
 |Date and Time|Check Out To|No|


### PR DESCRIPTION
Fixed spelling mistake in Desk Reservations list name (was Desks Reservations) and "Desk Text" field (was DeskText) for deployment to work correctly. Made list names more clear.